### PR TITLE
Document behaviour for non-retryable response codes + fix runtime links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -274,5 +274,9 @@ module.exports = {
       prefix: '/developer-console/docs/guides',
       url: 'https://developer.adobe.com'
     },
+    {
+      prefix: '/runtime/docs/guides',
+      url: 'https://developer.adobe.com'
+    },
   ],
 };

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -193,6 +193,10 @@ In general, `Adobe I/O Events` will always confirm that your webhook received an
 
 If `Adobe I/O Events` fails to receive a successful response code from your webhook within 10 seconds, it retries the request, including a special header `x-adobe-retry-count` (this header indicates how many times the delivery of an event or a batch of events has been attempted).
 
+<InlineAlert variant="info" slots="text"/>
+
+Please note that if an event delivery fails with a response status code of [400 Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) or [505 HTTP Version Not Supported](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/505), then those events are **not retried**.
+
 `Adobe I/O Events` will keep on retrying delivery to your webhook for **24 hours** using exponential and fixed backoff strategies. The first retry is attempted after 1 minute and the period between retries doubles after each attempt (second retry is after 2m, etc.), but is at most 15 minutes.
 
 If an event isn't delivered after 2 hours of retries, `Adobe I/O Events` marks the event registration as **Unstable**, but still keeps on attempting delivery. This gives you sufficient time to restore your webhook, and avoid it from getting marked as Disabled. Once restored, it will be marked as **Active** on the next successful event delivery.

--- a/src/pages/guides/runtime_webhooks.md
+++ b/src/pages/guides/runtime_webhooks.md
@@ -7,7 +7,7 @@ For long-running (async) actions and guaranteed event handling you should consid
 
 ## Setting up Webhook Integration with Runtime Action
 
-The Runtime cli will let you create a runtime action and hook it up with an integration via Adobe Developer Console. Read [here](/apis/experienceplatform/runtime/docs.html#!adobedocs/adobeio-runtime/master/getting-started/setup.md) to setup your cli with Runtime plugin which is required as pre-requisite.
+The Runtime cli will let you create a runtime action and hook it up with an integration via Adobe Developer Console. Read [here](/runtime/docs/guides/getting-started/setup/) to setup your cli with Runtime plugin which is required as pre-requisite.
 
 - Go to Developer Console and start creating an event registration
 - Add [Runtime](/developer-console/docs/guides/services/#enable-runtime) to your project, this will create the required auth and runtime namespace for you.
@@ -24,7 +24,7 @@ The Runtime cli will let you create a runtime action and hook it up with an inte
 
 ### Built In Signature Verification
 
-With integration between I/O Events and Adobe I/O Runtime, you don't need to worry about security as your runtime actions configured as webhooks are secured with an out-of-the-box signature verification implementation. So, basically whatever runtime action you use to create an event registration, the handler webhook created due to that will place a signature validator action along with your action as in a [sequence](/apis/experienceplatform/runtime/docs.html#!adobedocs/adobeio-runtime/master/reference/sequences_compositions.md). I/O Events signs the event payload with the client's secret signature and passes the signature as a request header while invoking your webhook. Your business logic runtime action will only be invoked once the validator action successfully verifies that the correct signature has been passed to invoke your webhook.
+With integration between I/O Events and Adobe I/O Runtime, you don't need to worry about security as your runtime actions configured as webhooks are secured with an out-of-the-box signature verification implementation. So, basically whatever runtime action you use to create an event registration, the handler webhook created due to that will place a signature validator action along with your action as in a [sequence](/runtime/docs/guides/reference/sequences_compositions/). I/O Events signs the event payload with the client's secret signature and passes the signature as a request header while invoking your webhook. Your business logic runtime action will only be invoked once the validator action successfully verifies that the correct signature has been passed to invoke your webhook.
 
 ### Tracing Actions with Activation Ids
 

--- a/src/pages/guides/using/marketo-user-audit-data-stream-setup.md
+++ b/src/pages/guides/using/marketo-user-audit-data-stream-setup.md
@@ -52,7 +52,7 @@ For basic instructions for this use case, starting from [console.adobe.io](/cons
       - The get request must respond with the challenge query if it exists
       - The post request must respond that it received the message or the webhook will re-attempt to send several times before giving up and automatically disabling the webhook sends
     - Enable Runtime action
-      - [See Setting up your Runtime Environment](/apis/experienceplatform/runtime/docs.html#!adobedocs/adobeio-runtime/master/getting-started/setup.md)
+      - [See Setting up your Runtime Environment](/runtime/docs/guides/getting-started/setup/)
       - Select a pre-made runtime action/runtime namespace
 - After Saving
 

--- a/src/pages/support/faq.md
+++ b/src/pages/support/faq.md
@@ -61,6 +61,10 @@ Yes:
 
 If `Adobe I/O Events` fails to receive a successful response code from your webhook within 10 seconds, it retries the request, including a special header `x-adobe-retry-count`. This header indicates how many times the delivery of an event or a batch of events has been attempted.
 
+<InlineAlert variant="info" slots="text"/>
+
+Please note that if an event delivery fails with a response status code of [400 Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) or [505 HTTP Version Not Supported](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/505), then those events are **not retried**.
+
 `Adobe I/O Events` will keep on retrying delivery to your webhook for **24 hours** using exponential and fixed backoff strategies. The first retry is attempted after 1 minute and the period between retries doubles after each attempt, but is at most 15 minutes (see below table outlining the retry pattern).
 <br/>
 
@@ -82,7 +86,9 @@ While your event registration is marked `Disabled`, Adobe will continue to log e
 
 ### What happens if my webhook is unable to handle a specific event but handles all other events gracefully?
 
-In this case, we will continue to retry the event delivery for 24 hours, but if all retry attempts get exhausted and the event still isn't delivered, then the event will be dropped.
+If an event delivery fails with a status code of [400 Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) or [505 HTTP Version Not Supported](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/505), then those events are **not retried**.
+
+For all other cases, we will continue to retry the event delivery for 24 hours, but if all retry attempts get exhausted and the event still isn't delivered, then the event will be dropped.
 However, do note that the event registration will remain as **Active** and shall continue to process events.
 
 ### Does every Adobe I/O Events webhook HTTP request come with a signature? 


### PR DESCRIPTION
## Description

This PR does the following:

- Fixes runtime specific links
- Documents behaviour for status codes for which events are not retried

## Screenshots (if appropriate):

<kbd>![webhook-faq](https://user-images.githubusercontent.com/6910192/146189391-c61a61ce-8f67-416e-89fa-ed5f1f89e15c.png)</kbd>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
