### PR TITLE
Quotas for the 'number of registrations'

### DIFF
--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -257,3 +257,13 @@ if (request.header('x-adobe-signature') !== hmac.digest('base64')) {
   throw new Error('x-adobe-signature HMAC check failed')
 }
 ```
+
+## Quotas
+
+There is an upper limit on the number of registrations that you can create. Following table lists the applicable quotas - 
+
+| Maximum number of registrations  | Grouping level | Description |
+| ------------- | ------------- | ------------- |
+| 2500  | IMS Org  | Maximum of 2500 event registrations (webhook or journal) can be created for an IMS Org  |
+| 10  | IMS Credential (client Id)  | Maximum of 10 event registrations (webhook or journal) can be created for an IMS client-id  |
+

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -262,8 +262,8 @@ if (request.header('x-adobe-signature') !== hmac.digest('base64')) {
 
 There is an upper limit on the number of registrations that you can create. Following table lists the applicable quotas - 
 
-| Maximum number of registrations  | Grouping level | Description |
-| ------------- | ------------- | ------------- |
-| 2500  | IMS Org  | Maximum of 2500 event registrations (webhook or journal) can be created for an IMS Org  |
-| 10  | IMS Credential (client Id)  | Maximum of 10 event registrations (webhook or journal) can be created for an IMS client-id  |
+| Maximum number of registrations  | Grouping level | Adjustable | Description |
+| ------------- | ------------- | ------------- | ------------- |
+| 2500  | IMS Org  | No | Maximum of 2500 event registrations (webhook or journal) can be created for an IMS Org. This quota cannot be adjusted.  |
+| 10  | IMS Credential (client Id) | Yes | Maximum of 10 event registrations (webhook or journal) can be created for an IMS client-id. If you have a use-case that requires more number of registrations, please contact us via [I/O Events Forum](https://experienceleaguecommunities.adobe.com/t5/adobe-i-o-events/ct-p/adobe-io-events) to get it adjusted. |
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR documents the following quotas for the 'number of registrations' -
1. I/O Events already has an upper limit on the "number of registrations per client Id". 
2. I/O Events will be adding another upper limit on the "number of registrations per ims-org". This change will be deployed on 20th Jan 2022, 12:00-17:00 IST. We do not anticipate any customer impact as all ims orgs are using way less number of registrations than the threshold value of **2500**.

## Motivation and Context

This change is being done to safeguard I/O Events services, and ensure stability and reliability in their performance.

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
