### PR TITLE
Add data residency info for custom events

### DIFF
--- a/src/pages/guides/api/eventsingress_api.md
+++ b/src/pages/guides/api/eventsingress_api.md
@@ -13,11 +13,11 @@ title: Events Publishing API
    * create your own `Custom Events Provider`
    * create at least one `Event Metadata` associated with the above
 
-<InlineAlert variant="help" slots="header, text1" />
+<InlineAlert slots="title, text"/>
 
 Data Residency:
 
-Please note that all custom events are stored in US East region. 
+Please note that all custom events are stored in the **United States (US)** region.  
 
 ## Throttling Policy
 

--- a/src/pages/guides/api/eventsingress_api.md
+++ b/src/pages/guides/api/eventsingress_api.md
@@ -13,6 +13,12 @@ title: Events Publishing API
    * create your own `Custom Events Provider`
    * create at least one `Event Metadata` associated with the above
 
+<InlineAlert variant="help" slots="header, text1" />
+
+Data Residency:
+
+Please note that all custom events are stored in US East region. 
+
 ## Throttling Policy
 
 We do have a throttling policy in place, we accept up to 3,000 requests / 5 secs per api-key.

--- a/src/pages/guides/sdk/sdk_publish_events.md
+++ b/src/pages/guides/sdk/sdk_publish_events.md
@@ -4,9 +4,15 @@ title: Publish Events | Adobe I/O Events SDK
 
 # Publish events
 
-Event publishers can publish events to the event receiver using the ADobe I/O Events SDK. 
+Event publishers can publish events to the event receiver using the Adobe I/O Events SDK. 
 
 For information on installing and using the SDK, please begin by reading the [getting started guide](sdk_getting_started.md).
+
+<InlineAlert variant="help" slots="header, text1" />
+
+Data Residency:
+
+Please note that all custom events are stored in US East region. 
 
 ## Method
 

--- a/src/pages/guides/sdk/sdk_publish_events.md
+++ b/src/pages/guides/sdk/sdk_publish_events.md
@@ -8,11 +8,11 @@ Event publishers can publish events to the event receiver using the Adobe I/O Ev
 
 For information on installing and using the SDK, please begin by reading the [getting started guide](sdk_getting_started.md).
 
-<InlineAlert variant="help" slots="header, text1" />
+<InlineAlert slots="title, text"/>
 
 Data Residency:
 
-Please note that all custom events are stored in US East region. 
+Please note that all custom events are stored in the **United States (US)** region.  
 
 ## Method
 

--- a/src/pages/guides/using/custom_events.md
+++ b/src/pages/guides/using/custom_events.md
@@ -27,11 +27,11 @@ Events are delivered in near real time, so consumers can respond immediately to 
 - **Build Cloud Native Adobe Apps**: 
 Build custom apps that interact with core Adobe services, and automate processes with event-based integrations using [Adobe Developer App Builder](/app-builder/docs/overview/) which comes with the ability to publish/consume Custom I/O Events. 
 
-<InlineAlert variant="help" slots="header, text1" />
+<InlineAlert slots="title, text"/>
 
 Data Residency:
 
-Please note that all custom events are stored in US East region.  
+Please note that all custom events are stored in the **United States (US)** region.  
 
 ## Get Started
 

--- a/src/pages/guides/using/custom_events.md
+++ b/src/pages/guides/using/custom_events.md
@@ -27,6 +27,12 @@ Events are delivered in near real time, so consumers can respond immediately to 
 - **Build Cloud Native Adobe Apps**: 
 Build custom apps that interact with core Adobe services, and automate processes with event-based integrations using [Adobe Developer App Builder](/app-builder/docs/overview/) which comes with the ability to publish/consume Custom I/O Events. 
 
+<InlineAlert variant="help" slots="header, text1" />
+
+Data Residency:
+
+Please note that all custom events are stored in US East region.  
+
 ## Get Started
 
 Register your `Custom Events Providers`, create event based registrations against these, and then start publishing events from your App Builder apps, using either:


### PR DESCRIPTION
## Description

This PR clarifies the data residency region for custom events. This information is added on main custom events doc and relevant API / SDK docs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/5928555/181729454-24e02d40-d22a-44b7-b9c5-d235f6f8073a.png">

Note - On my local machine, Gatsby did not render the header. It might be a bug. Title is also not being rendered for these examples too - https://github.com/adobe/aio-theme#inlinealert-block-updated-2022-06-08

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
