### PR TITLE
Remove readOnly for input models

### DIFF
--- a/static/events-api-reference.yaml
+++ b/static/events-api-reference.yaml
@@ -1108,51 +1108,43 @@ definitions:
       client_id:
         type: string
         description: Client id for which the registration is created, as obtained from Developer Console
-        readOnly: true
         minLength: 3
         maxLength: 255
       name:
         type: string
         description: The name of the webhook registration which will be displayed on Developer Console
-        readOnly: true
         minLength: 3
         maxLength: 255
       description:
         type: string
         description: The description of the registration
-        readOnly: true
         minLength: 0
         maxLength: 5000
       webhook_url:
         type: string
         description: (Optional) A valid webhook url where the events would be delivered
-        readOnly: true
         minLength: 0
         maxLength: 4000
       events_of_interest:
         type: array
         description: The events for which the registration is to be subscribed to
-        readOnly: true
         uniqueItems: true
         items:
           $ref: '#/definitions/EventsOfInterestInputModel'
       delivery_type:
         type: string
         description: Delivery type can either be webhook|webhook_batch|journal
-        readOnly: true
         pattern: webhook|webhook_batch|journal
         default: webhook
       runtime_action:
         type: string
         description: (Optional) Runtime action to be invoked by the published events
-        readOnly: true
         minLength: 0
         maxLength: 255
       enabled:
         type: boolean
         description: Enable or disable the registration
-        readOnly: true
-    description: the Input necessary to create an Adobe I/O Event Provider using the internal API
+    description: The Input Model necessary to create an Adobe I/O Events Registration
   RegistrationCollectionHalModel:
     type: object
     properties:
@@ -1224,44 +1216,37 @@ definitions:
       name:
         type: string
         description: The name of the webhook registration which will be displayed on Developer Console
-        readOnly: true
         minLength: 3
         maxLength: 255
       description:
         type: string
         description: The description of the registration
-        readOnly: true
         minLength: 0
         maxLength: 5000
       webhook_url:
         type: string
         description: (Optional) A valid webhook url where the events would be delivered
-        readOnly: true
         minLength: 0
         maxLength: 4000
       events_of_interest:
         type: array
         description: The events for which the registration is to be subscribed to
-        readOnly: true
         uniqueItems: true
         items:
           $ref: '#/definitions/EventsOfInterestInputModel'
       delivery_type:
         type: string
         description: Delivery type can either be webhook|webhook_batch|journal
-        readOnly: true
         pattern: webhook|webhook_batch|journal
         default: webhook
       runtime_action:
         type: string
         description: (Optional) Runtime action to be invoked by the published events
-        readOnly: true
         minLength: 0
         maxLength: 255
       enabled:
         type: boolean
         description: Enable or disable the registration
-        readOnly: true
     description: The Input Model necessary to PATCH/PUT an Adobe I/O Events Registration
   Trace:
     type: object


### PR DESCRIPTION
This will allow the inout models to be visible in the swagger page

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
