### PR TITLE
Fix links to create child pages under 'Runtime webhooks' section

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -45,11 +45,11 @@ module.exports = {
           },
           {
             title: "Runtime Actions As Webhook",
-            path: "guides/runtime_webhooks.md",
+            path: "guides/runtime_webhooks/index.md",
             pages: [
               {
                 title: "Automatic event registrations",
-                path: "guides/autoregistrations.md",
+                path: "guides/runtime_webhooks/autoregistrations.md",
               },
             ]
           },

--- a/src/pages/guides/runtime_webhooks/autoregistrations.md
+++ b/src/pages/guides/runtime_webhooks/autoregistrations.md
@@ -4,11 +4,11 @@ title: App Builder webhook auto registration
 
 # Overview
 
-The integration between [App builder project and I/O Events](./runtime_webhooks.md) allows to create applications that listen to Adobe events. Automatic events registrations push this concept further by subscribing your newly deployed project to `I/O Events` automatically, so you can easily deploy your application in different environments or even share your application with other organizations. Also, this technology minimizes the manual routine work for admins and reduces the possibility to mess up things during manual setup in `Developer Console`.
+The integration between [App builder project and I/O Events](/src/pages/guides/runtime_webhooks/index.md) allows to create applications that listen to Adobe events. Automatic events registrations push this concept further by subscribing your newly deployed project to `I/O Events` automatically, so you can easily deploy your application in different environments or even share your application with other organizations. Also, this technology minimizes the manual routine work for admins and reduces the possibility to mess up things during manual setup in `Developer Console`.
 
 ## Creating self-contained application
 In this chapter, we will create a code that listens to a specific event type and bind itself to this event type.
-* Create `App Builder` project(`Runtime`) with webhook using [App builder project and I/O Events](./runtime_webhooks.md) article. **DON'T go to `Developer Console` to create registrations!**
+* Create `App Builder` project(`Runtime`) with webhook using [App builder project and I/O Events](/src/pages/guides/runtime_webhooks/index.md) article. **DON'T go to `Developer Console` to create registrations!**
 * Install `aio-cli-plugin-extension` plugins using AIO CLI(`aio plugins discover -i`)
 * Declare your action as `non-web` and set `require-adobe-auth` to `false` in `app.config.yaml` file. Actions deployed with `aio-cli-plugin-extension` plugin only receive events signed by Adobe I/O Events. All other invocations will be ignored.
 * Define the event types you want to receive in `event-listener-for` section of `app.config.yaml` file like the following:

--- a/src/pages/guides/runtime_webhooks/index.md
+++ b/src/pages/guides/runtime_webhooks/index.md
@@ -40,7 +40,7 @@ With integration between I/O Events and Adobe I/O Runtime, you don't need to wor
 
 After setting up a runtime action as webhook, upon its successful invocation, you can see custom response returned from your own runtime action in the `Debug Tracing` webhook response section as below.
 
-![Debug Tracing Webhook Response New on Adobe Developer Console](./img/debug_tracing_webhook_response_new.png)
+![Debug Tracing Webhook Response on Adobe Developer Console](../img/debug_tracing_webhook_response_new.png)
 
 However, in case of any failed invocation to your webhook, you will get an error response body with an activation id for the same. This helps users to debug their actions as below
 
@@ -50,8 +50,8 @@ However, in case of any failed invocation to your webhook, you will get an error
    	- Your Runtime Action  
  - In case of failure in the signature verification step, this is how you will get the error response and the failed activation id for the same.
 
-    ![Activation Id for Failed Signature Verification](./img/activation_id_for_failed_signature.png)
+    ![Activation Id for Failed Signature Verification](../img/activation_id_for_failed_signature.png)
 
  - For failed invocation to your runtime action, you will get an error response with the failed activation id for the same like below
 
-    ![Activation Id for Failed User Action](./img/activation_id_for_failed_user_action.png)
+    ![Activation Id for Failed User Action](../img/activation_id_for_failed_user_action.png)

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -35,7 +35,7 @@ Whenever a matching event gets triggered, your application is notified.
   * [Adobe I/O Events API](guides/api/index.md)
   * [Adobe I/O Events CLI](guides/cli/index.md)
   * [Adobe I/O Events SDK](guides/sdk/index.md)
-  * [Automatic event registrations](guides/autoregistrations.md)
+  * [Automatic event registrations](guides/runtime_webhooks/autoregistrations.md)
 
 - [Ask questions, report bugs, make feature requests, and spark discussions](support/index.md).
 


### PR DESCRIPTION
This PR fixes links to create child pages under 'Runtime webhooks' section. This is to properly render documentation added in https://github.com/AdobeDocs/adobe-io-events/pull/50

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
