### PR TITLE
Remove AWS VIP program reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/icaraps"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^4.14.4",
+    "@adobe/gatsby-theme-aio": "^4.14.9",
     "experience-manager-apis": "https://github.com/AdobeDocs/experience-manager-apis",
     "gatsby": "4.22.0",
     "react": "^17.0.0",

--- a/src/pages/guides/amazon_eventbridge/index.md
+++ b/src/pages/guides/amazon_eventbridge/index.md
@@ -16,10 +16,6 @@ Amazon EventBridge is a serverless integration service that enables you to creat
 
 A customer AWS account and the corresponding AWS region where the events can be routed to.
 
-## Adobe I/O Events & AWS Eventbridge - VIP Program 
-
-You can sign up for the VIP program [here](https://forms.office.com/r/FvkPuSvqQ9). If you have questions or want to learn more about our VIP Program, please send us an email to Grp-CloudIntegration-Dev@adobe.com
-
 ## Getting Started
 
 ### Configuring Developer Console

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,108 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/gatsby-theme-aio@npm:^4.14.9":
+  version: 4.14.9
+  resolution: "@adobe/gatsby-theme-aio@npm:4.14.9"
+  dependencies:
+    "@adobe/focus-ring-polyfill": ^0.1.5
+    "@adobe/gatsby-source-github-file-contributors": ^0.3.1
+    "@adobe/prism-adobe": ^1.0.3
+    "@emotion/react": ^11.10.4
+    "@loadable/component": ^5.15.2
+    "@mdx-js/mdx": 1.6.22
+    "@mdx-js/react": 1.6.22
+    "@spectrum-css/accordion": 3.0.24
+    "@spectrum-css/actionbutton": 2.1.7
+    "@spectrum-css/actiongroup": ^2.0.0
+    "@spectrum-css/assetlist": 3.0.24
+    "@spectrum-css/badge": ^1.0.20
+    "@spectrum-css/breadcrumb": 5.0.0
+    "@spectrum-css/button": 6.0.13
+    "@spectrum-css/card": 5.0.0
+    "@spectrum-css/checkbox": 3.1.3
+    "@spectrum-css/contextualhelp": ^2.0.35
+    "@spectrum-css/dialog": 6.0.15
+    "@spectrum-css/divider": 1.0.27
+    "@spectrum-css/icon": 3.0.23
+    "@spectrum-css/inlinealert": 4.0.13
+    "@spectrum-css/link": 3.1.23
+    "@spectrum-css/menu": 4.0.4
+    "@spectrum-css/modal": 3.0.23
+    "@spectrum-css/picker": 1.2.12
+    "@spectrum-css/popover": 5.0.18
+    "@spectrum-css/progresscircle": 1.0.23
+    "@spectrum-css/search": 4.2.12
+    "@spectrum-css/sidenav": 3.0.24
+    "@spectrum-css/table": 4.0.19
+    "@spectrum-css/tabs": 3.2.19
+    "@spectrum-css/textfield": 3.2.4
+    "@spectrum-css/tooltip": 3.1.18
+    "@spectrum-css/typography": 4.0.20
+    "@spectrum-css/underlay": 2.0.31
+    "@spectrum-css/vars": 8.0.0
+    "@spectrum-css/well": 3.0.22
+    algolia-html-extractor: ^0.0.1
+    algoliasearch: ^4.14.2
+    await-exec: ^0.1.2
+    builtin-status-codes: ^3.0.0
+    classnames: ^2.3.2
+    core-js: ^3.25.1
+    file-saver: ^2.0.5
+    gatsby-plugin-algolia: ^0.26.0
+    gatsby-plugin-emotion: ^7.23.0
+    gatsby-plugin-layout: ^3.23.0
+    gatsby-plugin-mdx: ^3.20.0
+    gatsby-plugin-mdx-embed: ^1.0.0
+    gatsby-plugin-preact: ^6.23.0
+    gatsby-plugin-react-helmet: ^5.23.0
+    gatsby-plugin-sharp: ^4.23.0
+    gatsby-remark-autolink-headers: ^5.23.0
+    gatsby-remark-copy-linked-files: ^5.23.0
+    gatsby-remark-images-remote: ^2.1.1
+    gatsby-source-filesystem: ^4.23.0
+    gatsby-transformer-remark: ^5.23.0
+    gatsby-transformer-sharp: 4.23.0
+    https-browserify: ^1.0.0
+    jsdom: ^20.0.0
+    jszip: ^3.10.1
+    jszip-utils: ^0.1.0
+    lottie-web: ^5.9.6
+    mdx-embed: ^1.0.0
+    mobx: ^6.6.2
+    normalize-path: ^3.0.0
+    os-browserify: ^0.3.0
+    path-browserify: ^1.0.1
+    penpal: ^6.2.2
+    postcss: ^8.4.16
+    preact: ^10.11.0
+    preact-render-to-string: ^6.5.5
+    prism-react-renderer: 1.3.5
+    prop-types: ^15.8.1
+    react-helmet: ^6.1.0
+    react-id-generator: ^3.0.2
+    redoc: 2.0.0
+    redoc-cli: ^0.13.20
+    rehype-slug-custom-id: ^1.1.0
+    request: ^2.88.2
+    resize-observer-polyfill: ^1.5.1
+    sharp: 0.33.0
+    stream-http: ^3.2.0
+    styled-components: ^5.3.5
+    swiper: ^8.3.2
+    to-arraybuffer: ^1.0.1
+    tty-browserify: ^0.0.1
+    unist-util-select: 3.0.4
+    use-debounce: ^9.0.4
+    uuid: ^9.0.0
+  peerDependencies:
+    gatsby: ^4.22.0
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  checksum: 022e7c9b2698e2eac3fab0750454454c87a2f860c6eb6692543ba9d05103c4e23e149e150e442d8c1d206fe73e89be4f8e2c983e31ef3528e21b4cdbcb929bcc
+  languageName: node
+  linkType: hard
+
 "@adobe/prism-adobe@npm:^1.0.3":
   version: 1.0.3
   resolution: "@adobe/prism-adobe@npm:1.0.3"
@@ -11011,7 +11113,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dev-site-documentation-template@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": ^4.14.4
+    "@adobe/gatsby-theme-aio": ^4.14.9
     experience-manager-apis: "https://github.com/AdobeDocs/experience-manager-apis"
     gatsby: 4.22.0
     react: ^17.0.0


### PR DESCRIPTION
## Description
This PR does the following changes:
- Remove AWS VIP program reference
- Bumps @adobe/gatsby-theme-aio from 4.14.4 to 4.14.9

## Related Issue

<!--- Please link to the issue here: -->

## How Has This Been Tested?

`yarn run dev`

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
