### PR TITLE
Add default parameters for push to `main` branch in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,13 @@ jobs:
   set-state:
     runs-on: ubuntu-latest
     outputs:
-      deploy_prod: ${{ contains(github.event.inputs.env, 'prod') }}
-      deploy_dev: ${{ contains(github.event.inputs.env, 'dev') }}
-      clean_cache: ${{ contains(github.event.inputs.clean, 'yes') }}
+      deploy_prod: ${{ contains(github.event.inputs.env || 'dev prod', 'prod') }}
+      deploy_dev: ${{ contains(github.event.inputs.env || 'dev prod', 'dev') }}
+      clean_cache: ${{ contains(github.event.inputs.clean || 'no', 'yes') }}
       path_prefix: ${{ steps.get_path_prefix.outputs.path_prefix }}
       branch_short_ref: ${{ steps.get_branch.outputs.branch }}
-      exclude_subfolder: ${{ github.event.inputs.excludeSubfolder }}
+      exclude_subfolder: ${{ github.event.inputs.excludeSubfolder || '' }}
+      index_mode: ${{ github.event.inputs['index-mode'] || 'index' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -64,6 +65,7 @@ jobs:
       - run: echo "Repository branch - ${{ needs.set-state.outputs.branch_short_ref }}"
       - run: echo "Path prefix - ${{ needs.set-state.outputs.path_prefix }}"
       - run: echo "Exclude subfolder - ${{ needs.set-state.outputs.exclude_subfolder }}"
+      - run: echo "Index mode - ${{ needs.set-state.outputs.index_mode }}"
 
   pre-build-dev:
     needs: [set-state]


### PR DESCRIPTION
## Description
Add default parameters for push to `main` branch in deploy workflow
- **Default Values for `push` Events:**  
  The `set-state` job now checks if the inputs (`env`, `clean`, `excludeSubfolder`, and `index-mode`) are provided. If not (which happens when the workflow is triggered by a push), it uses default values (`dev prod` for `env`, `no` for `clean`, `""` for `excludeSubfolder`, and `index` for `index-mode`).

- **Conditional Logic:**  
  The `||` operator in `${{ github.event.inputs.env || 'dev prod' }}` ensures that if `env` is not set (which is the case for `push`), it falls back to `'dev prod'`.

## Related Issue

<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
