### PR TITLE
Update API endpoint in public docs to prod

### DIFF
--- a/static/events-api-reference.yaml
+++ b/static/events-api-reference.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: Adobe I/O Events API
   version: '2.0'
-host: api-stage.adobe.io
+host: api.adobe.io
 basePath: /
 tags:
   - name: Providers


### PR DESCRIPTION
## Description
 This PR updates the API endpoint in [our public docs](https://developer.adobe.com/events/docs/api/) to point to the prod endpoint. See current version below:

![Screenshot 2024-09-03 at 1 37 18 PM](https://github.com/user-attachments/assets/e28aab7b-5c15-45d5-b95e-761a0a9298f1)

## Related Issue

<!--- Please link to the issue here: -->

## How Has This Been Tested?

`yarn run dev`

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
