### PR TITLE
Adding Parliament manifest file

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,18 +1,125 @@
 type: navigation
 order: 1
-title: ADP Events documentation
+title: Adobe I/O Events
 pages:
   - title: Home
     url: /src/pages/index.md
 
-  - title: Introduction to Webhooks
+  - title: Guides
     url: /src/pages/guides/index.md
+    pages:
+      - title: Introduction to Adobe I/O Events Webhooks
+        url: /src/pages/guides/index.md
+      - title: Runtime Actions As Webhook
+        url: /src/pages/guides/runtime_webhooks/index.md
+        pages:
+          - title: Automatic event registrations
+            url: /src/pages/guides/runtime_webhooks/autoregistrations.md
+      - title: Introduction to Journaling
+        url: /src/pages/guides/journaling_intro.md
+      - title: Integration with Amazon EventBridge
+        url: /src/pages/guides/amazon_eventbridge/index.md
+      - title: App Builder Applications with I/O Events
+        url: /src/pages/guides/appbuilder/index.md
 
-  - title: Introduction to Journaling
-    url: /src/pages/guides/journaling_intro.md
-
-  - title: Introduction to Amazon EventBridge Integration
-    url: /src/pages/guides/amazon_eventbridge/index.md
-
-  - title: Events Integration with other Adobe solutions
+  - title: Using Adobe I/O Events
     url: /src/pages/guides/using/index.md
+    pages:
+    - title: Adobe Experience Platform Events
+      url: /src/pages/guides/using/experience-platform-event-setup.md
+
+    - title: AEM Events
+      url: /src/pages/guides/using/aem/index.md
+      pages:
+        - title: AEM Cloud Service Events
+          url: /src/pages/guides/using/aem/cloud-native/index.md
+        - title: AEM Events powered by AEM add-on module
+          url: /src/pages/guides/using/aem/aem-addon-module/index.md
+        - title: AEM Events FAQ
+          url: /src/pages/guides/using/aem/aem_faq.md
+
+    - title: Analytics Triggers Events
+      url: /src/pages/guides/using/analytics-triggers-event-setup.md
+
+    - title: Asset Events
+      url: /src/pages/guides/using/asset-events/asset-events-landing.md
+      pages:
+        - title: Asset Events Configuration
+          url: /src/pages/guides/using/asset-events/asset-events-configuration.md
+        - title: Asset Events Actions
+          url: /src/pages/guides/using/asset-events/asset-events-actions.md
+        - title: Asset Events Properties
+          url: /src/pages/guides/using/asset-events/asset-events-properties.md
+        - title: Asset Events Providers
+          url: /src/pages/guides/using/asset-events/asset-events-providers.md
+        - title: Asset Events Glossary
+          url: /src/pages/guides/using/asset-events/asset-events-glossary.md
+          
+    - title: Cloud Manager Events
+      url: /src/pages/guides/using/cloud-manager-events.md
+
+    - title: Custom Events
+      url: /src/pages/guides/using/custom_events.md
+
+    - title: InDesign APIs Events
+      url: /src/pages/guides/using/indesign-apis/indesign-apis-events-data-stream-setup.md
+
+    - title: Marketo Data Streams
+      url: /src/pages/guides/using/marketo/marketo-data-streams.md
+      pages:
+        - title: Lead Activity
+          url: /src/pages/guides/using/marketo/marketo-lead-activity-data-stream-setup.md
+        - title: User Audit
+          url: /src/pages/guides/using/marketo/marketo-user-audit-data-stream-setup.md
+        - title: Notification
+          url: /src/pages/guides/using/marketo/marketo-notification-data-stream-setup.md
+        - title: Observability (Beta)
+          url: /src/pages/guides/using/marketo/marketo-observability-data-stream-setup.md
+          
+    - title: Privacy Events
+      url: /src/pages/guides/using/privacy-event-setup.md
+
+  - title: API
+    url: /src/pages/guides/api/index.md
+    pages:
+      - title: Journaling API
+        url: /src/pages/guides/api/journaling_api.md
+      - title: Registration API
+        url: /src/pages/guides/api/registration_api.md
+      - title: Provider API
+        url: /src/pages/guides/api/provider_api.md
+      - title: Events Publishing API
+        url: /src/pages/guides/api/eventsingress_api.md
+
+  - title: CLI
+    url: /src/pages/guides/cli/index.md
+
+  - title: SDK
+    url: /src/pages/guides/sdk/index.md
+    pages:
+      - title: Getting Started with Events SDK
+        url: /src/pages/guides/sdk/sdk_getting_started.md
+      - title: Event Metadata
+        url: /src/pages/guides/sdk/sdk_event_metadata.md
+      - title: Journaling
+        url: /src/pages/guides/sdk/sdk_journaling.md
+      - title: Providers
+        url: /src/pages/guides/sdk/sdk_providers.md
+      - title: Publish Events
+        url: /src/pages/guides/sdk/sdk_publish_events.md
+      - title: Signature Verification
+        url: /src/pages/guides/sdk/sdk_signature_verification.md
+      - title: Webhooks
+        url: /src/pages/guides/sdk/sdk_webhooks.md
+
+  - title: Support
+    url: /src/pages/support/index.md
+    pages:
+      - title: Debugging
+        url: /src/pages/support/debug.md
+      - title: Tracing
+        url: /src/pages/support/tracing.md
+      - title: Forums
+        url: https://experienceleaguecommunities.adobe.com/t5/adobe-developer/ct-p/adobe-io
+      - title: Frequently Asked Questions (FAQ)
+        url: /src/pages/support/faq.md

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,18 @@
+type: navigation
+order: 1
+title: ADP Events documentation
+pages:
+  - title: Home
+    url: /src/pages/index.md
+
+  - title: Introduction to Webhooks
+    url: /src/pages/guides/index.md
+
+  - title: Introduction to Journaling
+    url: /src/pages/guides/journaling_intro.md
+
+  - title: Introduction to Amazon EventBridge Integration
+    url: /src/pages/guides/amazon_eventbridge/index.md
+
+  - title: Events Integration with other Adobe solutions
+    url: /src/pages/guides/using/index.md


### PR DESCRIPTION
This manifest file will allow these same documents to be reflected on Adobe's internal developer portal.