### PR TITLE
Adding changes for 2 new events

### DIFF
--- a/src/pages/guides/using/indesign-apis/indesign-apis-events-data-stream-setup.md
+++ b/src/pages/guides/using/indesign-apis/indesign-apis-events-data-stream-setup.md
@@ -201,7 +201,7 @@ ASSET_DOWNLOAD_CANCELLED | Downloading of an individual asset was cancelled beca
 ASSET_SCANNING_STARTED | Scanning the downloaded asset
 ASSET_SCANNING_COMPLETED | Scanning of an individual asset is completed
 ASSET_DOWNLOAD_FAILED | Individual downloading of an asset has failed
-ASSET_SECURITY_CHECK_FAILED | Individual asset is infected and security check failed
+ASSET_SECURITY_CHECK_FAILED | An individual asset is infected and security check failed
 ASSET_SCANNING_FAILED | Individual scanning of an asset has failed
 ASSETS_DOWNLOAD_COMPLETED | Downloading of all assets is completed
 ENGINE_PROCESSING_STARTED | The job was handed over to engine to be processed

--- a/src/pages/guides/using/indesign-apis/indesign-apis-events-data-stream-setup.md
+++ b/src/pages/guides/using/indesign-apis/indesign-apis-events-data-stream-setup.md
@@ -196,10 +196,12 @@ Event state | Description
 QUEUED | The job is not yet running
 ASSETS_DOWNLOAD_STARTED | Downloading has started for assets required to run this job
 ASSET_DOWNLOAD_STARTED | Emitted for individual assets, once for each asset that is downloaded
-ASSET_SCANNING_STARTED | Scanning the downloaded asset
 ASSET_DOWNLOAD_COMPLETED | Downloading of an individual asset is completed
+ASSET_DOWNLOAD_CANCELLED | Downloading of an individual asset was cancelled because of failure during downloading of another asset
+ASSET_SCANNING_STARTED | Scanning the downloaded asset
 ASSET_SCANNING_COMPLETED | Scanning of an individual asset is completed
 ASSET_DOWNLOAD_FAILED | Individual downloading of an asset has failed
+ASSET_SECURITY_CHECK_FAILED | Individual asset is infected and security check failed
 ASSET_SCANNING_FAILED | Individual scanning of an asset has failed
 ASSETS_DOWNLOAD_COMPLETED | Downloading of all assets is completed
 ENGINE_PROCESSING_STARTED | The job was handed over to engine to be processed


### PR DESCRIPTION
## Description

We have added two new events in indesign apis. 
1. ASSET_DOWNLOAD_CANCELLED: This status is set or the rest of the assets in case download of an asset fails.
2. ASSET_SECURITY_CHECK_FAILED: This status is set to notify user that the asset they are sending as an input might be infected since its failing the scan check.

