### PR TITLE
Add details around seek parameter in journaling

### DIFF
--- a/src/pages/guides/api/journaling-api.md
+++ b/src/pages/guides/api/journaling-api.md
@@ -433,6 +433,31 @@ Link: </events/organizations/23294/integrations/54108/f89067f2-0d50-4bb2-bf78-20
 }
 ```
 
+### Starting from a specific point in time with the `seek` parameter
+
+The Journaling API supports a `seek` query parameter, which allows you to start fetching events from a specific point in time, rather than from the oldest or most recent event. This is especially useful when you want to inspect or extract events from a particular time window.
+
+The `seek` parameter accepts values in [ISO 8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations), such as:
+
+* `-PT2H` (2 hours ago)
+* `-P1D` (1 day ago)
+* `-P5DT2H` (5 days and 2 hours ago)
+
+For example, to fetch events starting from 2 hours ago:
+
+```bash
+curl -X GET \
+  https://events.adobe.io/events/organizations/23294/integrations/54108/f89067f2-0d50-4bb2-bf78-209d0eacb6eb/events?seek=-PT2H \
+  -H "x-ims-org-id: 4CC7D9704674CFB2138A2C54@AdobeOrg" \
+  -H "Authorization: Bearer $USER_TOKEN" \
+  -H "x-api-key: $API_KEY"
+```
+
+**Note:**
+
+* Use the `seek` parameter to seek to a particular point in time in the journal. For subsequent requests, use the `since` parameter as provided in the `next` link from the API response to actually traverse the journal from that point.
+* `seek` and `since` parameters cannot be used together in the same request.
+
 ### Consuming the most recent events
 
 The Journaling endpoint URL when supplied with no query parameters returns the oldest entries in ledger, however, sometimes a client application is not interested in consuming older events. In such a case, the client application can jump straight to the "end" of the journal and start consuming events that are written to the journal after the request was made.

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -15,7 +15,7 @@ import ReceivingEventsForUsersDoc from '../common/receiving-events-for-users-doc
 # Introduction to Adobe I/O Events Webhooks
 
 With Adobe I/O Events webhooks, your application can sign up to be notified whenever certain events occur.
-For example, when a user uploads a asset, this action generates an event.
+For example, when a user uploads an asset, this action generates an event.
 With the right webhook in place, your application is instantly notified that this event happened.
 
 Please refer to the `Adobe Developer Console` documentation on how to [Add Events to a project](http://developer.adobe.com/developer-console/docs/guides/services/services-add-event)

--- a/src/pages/guides/journaling-intro.md
+++ b/src/pages/guides/journaling-intro.md
@@ -12,8 +12,10 @@ every enterprise integration that is registered for events is automatically enab
 Journaling data is retained for 7 days.
 
 Important Takeaways on Journaling:
+
 - Stores up to 7 days of history
 - Can be iterated through from any previous event within the history
+- Supports starting from a [specific point in time]((./api/journaling-api.md#starting-from-a-specific-point-in-time-with-the-seek-parameter)) using the `seek` parameter, which is useful for time-based investigations.
 - Will still receive and store events even if webhook is failing
 - Useful for fetching events that were missed due to webhook issues or for a pulling mechanism instead of webhook push
 

--- a/src/pages/guides/journaling-intro.md
+++ b/src/pages/guides/journaling-intro.md
@@ -4,23 +4,22 @@ title: Journaling Introduction
 
 # Journaling
 
-For enterprise developers, Adobe offers another way to consume events besides webhooks: journaling.
-The Adobe I/O Events Journaling API enables enterprise integrations to consume events according
-to their own cadence and process them in bulk.
-Unlike webhooks, no additional registration or other configuration is required;
-every enterprise integration that is registered for events is automatically enabled for journaling.
-Journaling data is retained for 7 days.
+The Adobe I/O Events [Journaling API](./api/journaling-api.md) allows enterprise integrations to retrieve events at their own pace and process them in bulk.
+For enterprise developers, Adobe provides an alternative method for consuming events beyond all push-based deliveries ([Webhooks](./index.md), [Amazon EventBridge](./amazon-eventbridge/index.md), and [Runtime](./runtime-webhooks/index.md)): **Journaling**.
 
-Important Takeaways on Journaling:
+Unlike _push-based_ deliveries, journaling requires no additional registration or configuration, and uses a **pull-based** model for consuming events.
+With journaling, your application issues a series of API calls to retrieve batches of one or more events from the journal.
+Every enterprise integration registered for events is automatically enabled for journaling.
 
-- Stores up to 7 days of history
-- Can be iterated through from any previous event within the history
-- Supports starting from a [specific point in time]((./api/journaling-api.md#starting-from-a-specific-point-in-time-with-the-seek-parameter)) using the `seek` parameter, which is useful for time-based investigations.
-- Will still receive and store events even if webhook is failing
-- Useful for fetching events that were missed due to webhook issues or for a pulling mechanism instead of webhook push
+**Key Benefits of Journaling:**
 
-Journaling, in contrast to webhooks, is a _pull_ model of consuming events, whereas webhooks are a _push_ model.
-In journaling your application will issue a series of API calls to pull batches of one or more events from the journal.
+- Retains up to 7 days of event history
+- Allows iteration from any previous event within the retention window
+- Supports starting from a [specific point in time](./api/journaling-api.md#starting-from-a-specific-point-in-time-with-the-seek-parameter) using the `seek` parameter
+- Continues to receive and store events even if your push-based deliveries are failing
+- Enables retrieval of missed events due to push-based delivery failures
+
+## Resources
 
 - [Get started with the Journaling API](./api/journaling-api.md)
 - [Journaling FAQ](../support/faq.md#journaling-faq)

--- a/src/pages/guides/journaling-intro.md
+++ b/src/pages/guides/journaling-intro.md
@@ -4,11 +4,11 @@ title: Journaling Introduction
 
 # Journaling
 
-For enterprise developers, Adobe offers another way to consume events besides webhooks: journaling. 
-The Adobe I/O Events Journaling API enables enterprise integrations to consume events according 
-to their own cadence and process them in bulk. 
-Unlike webhooks, no additional registration or other configuration is required; 
-every enterprise integration that is registered for events is automatically enabled for journaling. 
+For enterprise developers, Adobe offers another way to consume events besides webhooks: journaling.
+The Adobe I/O Events Journaling API enables enterprise integrations to consume events according
+to their own cadence and process them in bulk.
+Unlike webhooks, no additional registration or other configuration is required;
+every enterprise integration that is registered for events is automatically enabled for journaling.
 Journaling data is retained for 7 days.
 
 Important Takeaways on Journaling:
@@ -19,8 +19,8 @@ Important Takeaways on Journaling:
 - Will still receive and store events even if webhook is failing
 - Useful for fetching events that were missed due to webhook issues or for a pulling mechanism instead of webhook push
 
-Journaling, in contrast to webhooks, is a _pull_ model of consuming events, whereas webhooks are a _push_ model. 
+Journaling, in contrast to webhooks, is a _pull_ model of consuming events, whereas webhooks are a _push_ model.
 In journaling your application will issue a series of API calls to pull batches of one or more events from the journal.
 
-* [Get started with the Journaling API](./api/journaling-api.md)
-* [Journaling FAQ](../support/faq.md#journaling-faq)
+- [Get started with the Journaling API](./api/journaling-api.md)
+- [Journaling FAQ](../support/faq.md#journaling-faq)

--- a/src/pages/guides/sdk/sdk-journaling.md
+++ b/src/pages/guides/sdk/sdk-journaling.md
@@ -25,8 +25,9 @@ The following options can be configured while calling the journaling API:
 | Name | Type | Description |
 |---|---|---|
 | [latest] | boolean | *Optional.* By default, the latest is set to false and all events are read from the first valid position in the journal. If set to true, Messages will be read from the latest position. |
-| [since] | string | *Optional.* Provide the position in the journal from where events must be fetched. If not specified and latests=false, messages are fetched from the first valid position in the journal. |
+| [since] | string | *Optional.* Provide the position in the journal from where events must be fetched. If not specified and `latest=false`, messages are fetched from the first valid position in the journal. |
 | [limit] | number | Maximum number of events returned in the response. Note: unless the events are created at a high frequency, chances are the number of messages will be less than the specified limit value (see our [Journaling API](../api/journaling-api.md#limiting-the-size-of-the-batch) for more details) |
+| [seek] | string | *Optional.* Start fetching events from a specific point in time, using an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (e.g., `-PT2H` for 2 hours ago, `-P1D` for 1 day ago). Useful for [time-based queries](../api/journaling-api.md#starting-from-a-specific-point-in-time-with-the-seek-parameter). |
 
 ### EventsJournalPollingOptions
 
@@ -39,6 +40,8 @@ The following options can be configured while calling the journaling API:
 The `getEventsFromJournal` SDK expects a journal URL as input and `eventsJournalOptions` if required. If no parameters are specified, messages are fetched from the first valid position in the journal, and the `link.next` header in the response provides the position for the next event in the journal. Following the `link.next` link from each response will help fetch all events in order from the journal.
 
 You can also rewind to start reading from a different position in the journal by providing the `since` query parameter in the options or as part of the journal URL.
+
+Alternatively, you can start from a specific point in time using the `seek` parameter (e.g., `{ seek: '-PT2H' }` to start from 2 hours ago).
 
 ### Method
 

--- a/src/pages/guides/sdk/sdk-journaling.md
+++ b/src/pages/guides/sdk/sdk-journaling.md
@@ -4,17 +4,17 @@ title: Subscribe to Events Using Journaling | Adobe I/O Events SDK
 
 # Subscribe to Events Using Journaling
 
-Journaling is a *pull* model of consuming events, unlike [webhooks](sdk-webhooks.md) which use a *push* model. In journaling, your application will issue a series of API calls to pull batches of one or more events from the journal. 
+Journaling is a *pull* model of consuming events, unlike [webhooks](sdk-webhooks.md) which use a *push* model. In journaling, your application will issue a series of API calls to pull batches of one or more events from the journal.
 
-The Adobe I/O Events Journaling API response contains event data and the unique position in the journal for every event returned in that batch, and enables applications to consume events according to their own cadence and process them in bulk. 
+The Adobe I/O Events Journaling API response contains event data and the unique position in the journal for every event returned in that batch, and enables applications to consume events according to their own cadence and process them in bulk.
 
 Unlike webhooks, no additional registration or other configuration is required; every application that is registered for events is automatically enabled for journaling. Journaling data is retained for 7 days.
 
-For information on installing and using the SDK, see
+For information on installing and using the SDK, see:
+
 * our [getting started guide](sdk-getting-started.md)
 * our [Journaling API](../api/journaling-api.md) documentation
 * our [Journaling API FAQ](../../support/faq.md#journaling-faq)
-
 
 ## Configuration Options
 
@@ -22,34 +22,34 @@ The following options can be configured while calling the journaling API:
 
 ### EventsJournalOptions
 
-|Name	|Type	|Description|
+| Name | Type | Description |
 |---|---|---|
-|[latest]	|boolean	|*Optional.* By default, the latest is set to false and all events are read from the first valid position in the journal. If set to true, Messages will be read from the latest position. |
-|[since]	|string	|*Optional.* Provide the position in the journal from where events must be fetched. If not specified and latests=false, messages are fetched from the first valid position in the journal.|
-|[limit]	|number	|Maximum number of events returned in the response. Note: unless the events are created at a high frequency, chances are the number of messages will be less than the specified limit value (see our [Journaling API](../api/journaling-api.md#limiting-the-size-of-the-batch) for more details)|
+| [latest] | boolean | *Optional.* By default, the latest is set to false and all events are read from the first valid position in the journal. If set to true, Messages will be read from the latest position. |
+| [since] | string | *Optional.* Provide the position in the journal from where events must be fetched. If not specified and latests=false, messages are fetched from the first valid position in the journal. |
+| [limit] | number | Maximum number of events returned in the response. Note: unless the events are created at a high frequency, chances are the number of messages will be less than the specified limit value (see our [Journaling API](../api/journaling-api.md#limiting-the-size-of-the-batch) for more details) |
 
 ### EventsJournalPollingOptions
 
-|Name	|Type	|Description|
+| Name | Type | Description |
 |---|---|---|
-|[interval]	|number	|*Optional.* Interval at which to poll the journal; If not provided, a default value will be used. The default value is 2s and is used only in case there are no new events in the journal or in case of error. Otherwise, the new event is fetched immediately after the previous call.|
+| [interval] | number | *Optional.* Interval at which to poll the journal; If not provided, a default value will be used. The default value is 2s and is used only in case there are no new events in the journal or in case of error. Otherwise, the new event is fetched immediately after the previous call. |
 
 ## Get Events from a Journal
 
-The `getEventsFromJournal` SDK expects a journal URL as input and `eventsJournalOptions` if required. If no parameters are specified, messages are fetched from the first valid position in the journal, and the `link.next` header in the response provides the position for the next event in the journal. Following the `link.next` link from each response will help fetch all events in order from the journal. 
+The `getEventsFromJournal` SDK expects a journal URL as input and `eventsJournalOptions` if required. If no parameters are specified, messages are fetched from the first valid position in the journal, and the `link.next` header in the response provides the position for the next event in the journal. Following the `link.next` link from each response will help fetch all events in order from the journal.
 
-You can also rewind to start reading from a different position in the journal by providing the `since` query parameter in the options or as part of the journal URL. 
+You can also rewind to start reading from a different position in the journal by providing the `since` query parameter in the options or as part of the journal URL.
 
-#### Method
+### Method
 
 ```shell
 getEventsFromJournal(journalUrl, [eventsJournalOptions]) ⇒ Promise
 ```
 
-|Parameter|	Type	|Description|
+| Parameter | Type | Description |
 |---|---|---|
-|`journalUrl`	|string	| ***Required.*** URL of the journal or 'next' link to read from. `journalUrl` can be fetched by fetching the registration details. In the response body, it is the `events_url`.|
-|[eventsJournalOptions]	|[EventsJournalOptions](#eventsjournaloptions)	|Query options to send with the URL.|
+| `journalUrl` | string | ***Required.*** URL of the journal or 'next' link to read from. `journalUrl` can be fetched by fetching the registration details. In the response body, it is the `events_url`. |
+| [eventsJournalOptions] | [EventsJournalOptions](#eventsjournaloptions) | Query options to send with the URL. |
 
 #### Sample Response
 
@@ -59,7 +59,7 @@ The response from the SDK contains the following as part of the json result:
 |---|---|
 |`events`| Array of events retrieved from the journal.|
 |`links`| Links to the next/latest/current position from where the event is to be fetched.|
-|`retryAfter`| If the call to journal returned 204, it means that there are no more events to be read from the journal. The `retryAfter` value extracted from the `retry-after` header in the response specifies the time in seconds after which one can try again to look for more events. *It is recommended to honor this `retryAfter` value.*| 
+|`retryAfter`| If the call to journal returned 204, it means that there are no more events to be read from the journal. The `retryAfter` value extracted from the `retry-after` header in the response specifies the time in seconds after which one can try again to look for more events. *It is recommended to honor this `retryAfter` value.*|
 
 ```json
 { "events":
@@ -96,29 +96,29 @@ The response from the SDK contains the following as part of the json result:
 
 ## Get Events Observable from Journal
 
-Polling the journal for events and taking action on each event such as mapping, transformations, 
-and filtering are some common functionalities that are most useful using the Journaling API. 
+Polling the journal for events and taking action on each event such as mapping, transformations,
+and filtering are some common functionalities that are most useful using the Journaling API.
 
-This method encapsulates all of the complexities of fetching events by following the `link.next` and `retry-After` headers 
-while you can focus on implementing the business logic of taking action on receiving events 
-(and as mentioned in our [Journaling API documentation](../api/journaling-api.md#fetching-the-next-batch-of-newer-events-from-the-journal), 
+This method encapsulates all of the complexities of fetching events by following the `link.next` and `retry-After` headers
+while you can focus on implementing the business logic of taking action on receiving events
+(and as mentioned in our [Journaling API documentation](../api/journaling-api.md#fetching-the-next-batch-of-newer-events-from-the-journal),
 utilizing this link is **strongly recommended**).
 
-#### Method
+### Method
 
 ```shell
 getEventsObservableFromJournal(journalUrl, [eventsJournalOptions], [eventsJournalPollingOptions]) ⇒ Observable
 ```
 
-|Parameter|	Type	|Description|
+| Parameter | Type | Description |
 |---|---|---|
-|`journalUrl`	|string	| ***Required.*** URL of the journal or 'next' link to read from. `journalUrl` can be fetched by fetching the registration details. In the response body, it is the `events_url`.|
-|[eventsJournalOptions]	|[EventsJournalOptions](#eventsjournaloptions)	|Query options to send with the URL.|
-|[eventsJournalPollingOptions]|	[EventsJournalPollingOptions](#eventsjournalpollingoptions)	|Journal polling options.|
+| `journalUrl` | string | ***Required.*** URL of the journal or 'next' link to read from. `journalUrl` can be fetched by fetching the registration details. In the response body, it is the `events_url`. |
+| [eventsJournalOptions] | [EventsJournalOptions](#eventsjournaloptions) | Query options to send with the URL. |
+| [eventsJournalPollingOptions] | [EventsJournalPollingOptions](#eventsjournalpollingoptions) | Journal polling options. |
 
 #### Sample Code
 
-This method returns an [RxJS Observable](https://rxjs.dev/guide/observable) which you can fetch and subscribe to in order to listen to events. The following code explains how to get started with journaling: 
+This method returns an [RxJS Observable](https://rxjs.dev/guide/observable) which you can fetch and subscribe to in order to listen to events. The following code explains how to get started with journaling:
 
 ```javascript
 const sdk = require('@adobe/aio-lib-events')
@@ -130,7 +130,7 @@ async function sdkTest() {
   const journaling = client.getEventsObservableFromJournal('<journal url>', '<journaling options>')
 ```
 
-The simplest way to subscribe and take action on the next event is as follows: 
+The simplest way to subscribe and take action on the next event is as follows:
 
 ```javascript
 journaling.subscribe(
@@ -139,7 +139,7 @@ journaling.subscribe(
     () => console.log('onCompleted')) //action onComplete
 ```
 
-RxJS provides a lot of flexibility in handling events. You can compose functions declaratively in sequence to work on the emitted data. 
+RxJS provides a lot of flexibility in handling events. You can compose functions declaratively in sequence to work on the emitted data.
 
 For more complicated use cases, you can make use of [RxJS operators](https://rxjs.dev/guide/operators) to filter certain events, transform the events, etc. Such an implementation would look something like:
 
@@ -165,7 +165,6 @@ setTimeout(() => {
 ```
 
 You can also have multiple subscriptions to a single observable, each transforming and filtering events on different criteria or applying any other operators as follows:
-
 
 ```javascript
 const { filter, map } = require('rxjs/operators')

--- a/src/pages/support/faq.md
+++ b/src/pages/support/faq.md
@@ -155,6 +155,11 @@ No, our journaling API does not support retrieving all events in a single query.
 
 However, by using the `since` parameter, you can fetch events incrementally by following the journal's [rel=next Link](../guides/api/journaling-api.md#fetching-the-next-batch-of-newer-events-from-the-journal) in the response headers until all events have been retrieved.
 
+### Is there a way to start fetching events from a specific point in time?
+
+Yes, you can use the `seek` parameter with the Journaling API to start fetching events from a specific point in time, using an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (e.g., `-PT2H` for 2 hours ago, `-P1D` for 1 day ago).
+This is especially useful for investigating events within a particular time window. See our [Journaling API documentation](../guides/api/journaling-api.md#starting-from-a-specific-point-in-time-with-the-seek-parameter) for more details and examples.
+
 ## Custom Events FAQ
 
 ### I created a `Custom Events Provider`, why is it not showing up in the `Adobe Developer Console`?


### PR DESCRIPTION
## Description

This PR does the following:
- [Adds details around seek parameter](https://github.com/AdobeDocs/adobe-io-events/commit/1c7ccd9247a6d81bd5e70cd3b030a37b8870051a)
- [Rewrites journal intro doc to remove redundancy](https://github.com/AdobeDocs/adobe-io-events/commit/5c1b0f1de7c6c514410b1afd359735b3c01c7f9c)
- [Fixes grammatical mistake](https://github.com/AdobeDocs/adobe-io-events/commit/0e5fa098a019adfd02482a5a3c60b4e9654a150b) reported in https://github.com/AdobeDocs/adobe-io-events/issues/175

## Related Issue

https://github.com/AdobeDocs/adobe-io-events/issues/175

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Markdown preview on IDE. No other way to test locally right now.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
