### PR TITLE
Update journaling swagger API referece with descriptions + Update GH deploy action to trigger on merging to `main`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,16 @@
 ---
 name: Deployment
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       env:
         description: "Select environment to deploy to"
         type: choice
         required: true
-        default: "stage"
+        default: "stage & prod"
         options:
           - stage
           - prod
@@ -26,6 +29,6 @@ jobs:
     name: Deployment
     uses: AdobeDocs/adp-devsite-workflow/.github/workflows/deploy.yml@main
     with:
-      env: ${{ inputs.env }}
-      baseSha: ${{ inputs.baseSha }}
-      deployAll: ${{ inputs.deployAll }}
+      env: ${{ github.event_name == 'workflow_dispatch' && inputs.env || 'stage & prod' }}
+      baseSha: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSha || '' }}
+      deployAll: ${{ github.event_name == 'workflow_dispatch' && inputs.deployAll || false }}

--- a/static/events-api-reference.yaml
+++ b/static/events-api-reference.yaml
@@ -397,10 +397,12 @@ paths:
           required: false
           type: integer
           format: int32
+          description: Maximum number of events to return in the batch
         - name: since
           in: query
-          required: false
+          required: true
           type: string
+          description: Position in the journal to fetch events from
       responses:
         default:
           description: successful operation
@@ -426,18 +428,22 @@ paths:
           required: false
           type: integer
           format: int32
+          description: Maximum number of events to return in the batch
         - name: since
           in: query
           required: false
           type: string
+          description: Position in the journal to fetch events from (cannot be used with `seek` parameter)
         - name: seek
           in: query
           required: false
           type: string
+          description: ISO 8601 duration format to seek to a specific point in time (e.g., -PT2H for 2 hours ago, -P1D for 1 day ago)
         - name: latest
           in: query
           required: false
           type: boolean
+          description: Jump to the end of the journal to start consuming the most recent events
       responses:
         default:
           description: successful operation


### PR DESCRIPTION
## Description

This PR does the following:
- [Adds descriptions for journaling API swagger doc](https://github.com/AdobeDocs/adobe-io-events/commit/5f297d1d308a6e48763611bc5db567d062a9a5ee)
- [Updates github action to deploy automatically on merging to main branch](https://github.com/AdobeDocs/adobe-io-events/commit/960cee86d44040378cd362f8a4857479886f3f97)

## Related Issue

<!--- Please link to the issue here: -->

## How Has This Been Tested?

Swagger reference cannot be locally tested.

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
