### PR TITLE
Fix github action deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,4 +31,4 @@ jobs:
     with:
       env: ${{ github.event_name == 'workflow_dispatch' && inputs.env || 'stage' }}
       baseSha: ${{ github.event_name == 'workflow_dispatch' && inputs.baseSha || '' }}
-      deployAll: ${{ github.event_name == 'workflow_dispatch' && inputs.deployAll || 'true' }}
+      deployAll: true


### PR DESCRIPTION
## Description

This PR fixes the github action deployment workflow that got broken in the previous PR (https://github.com/AdobeDocs/adobe-io-events/pull/181) because of https://github.com/AdobeDocs/adobe-io-events/pull/181/commits/e551076cb8b7d4b5f9249c29785bd22575da6be8.
- We need to use a `boolean` instead of `string`
- Always defaulting this to be `true` regardless of the trigger (manual or push to `main`).

## Related Issue

<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
