### PR TITLE
Avoid hiding search field while navigating API reference page

### DIFF
--- a/src/pages/api.md
+++ b/src/pages/api.md
@@ -3,4 +3,4 @@ layout: none
 ---
 
 <RedoclyAPIBlock
-src="/events-api-reference.yaml" />
+    src="/events-api-reference.yaml" scrollYOffset={64} />


### PR DESCRIPTION
## Description

Avoid hiding search field while navigating API reference page (see [Slack thread](https://adobeio.slack.com/archives/C01GU3V8XE0/p1756986629105089?thread_ts=1755008609.171399&cid=C01GU3V8XE0)) for more details

## Related Issue

<!--- Please link to the issue here: -->

## How Has This Been Tested?

No way to test API reference locally

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
