### PR TITLE
Remove provider-specific wording from shared path parameter descriptions

### DIFF
--- a/static/events-api-reference.yaml
+++ b/static/events-api-reference.yaml
@@ -1006,19 +1006,19 @@ parameters:
   consumerOrgId:
     name: consumerOrgId
     in: path
-    description: Consumer Organization ID (owning the provider)
+    description: Consumer Organization ID
     required: true
     type: string
   projectId:
     name: projectId
     in: path
-    description: Project ID where the event provider belongs
+    description: Project ID
     required: true
     type: string
-  workspaceId:      
+  workspaceId:
     name: workspaceId
     in: path
-    description: Workspace ID where the event provider belongs
+    description: Workspace ID
     required: true
     type: string
   providerId:


### PR DESCRIPTION
## Description

- Path params consumerOrgId, projectId, and workspaceId were described as belonging to or owning a provider, which was incorrect for registration endpoints.
- Made descriptions neutral so they are accurate across both provider and registration endpoints.

## Related Issue

Jira: CI-8174

## How Has This Been Tested?

https://github.com/AdobeDocs/adp-devsite-utils/blob/main/README.md#quick-start

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.