### PR TITLE
CI-8178: Update docs related to limit parameter for journaling

### DIFF
--- a/src/pages/guides/api/journaling-api.md
+++ b/src/pages/guides/api/journaling-api.md
@@ -291,18 +291,16 @@ Link: </events/organizations/23294/integrations/54108/f89067f2-0d50-4bb2-bf78-20
 
 ### Limiting the size of the batch
 
-When events are created at a high frequency, Journal persists groups of events in its storage units;
-when events are created at a lower rate, these storage units will contain only one event.
+When no `limit` parameter is specified, the API returns a default number of events per request, though it may return more during high-volume periods.
 
-Hence, depending on the traffic of the events associated with your registration,
-the number of events returned in a single response batch varies:
-a batch of events contains at least one event (if you are not already at the end of the journal),
-but there is no pre-defined upper limit.
+To control exactly how many events are returned per request, supply the `limit` query parameter with a positive integer. When specified:
 
-In case you wish to set an upper bound, you can supply the `limit` query parameter with the maximum number
-of events that may be returned by the API.
+- The API returns **exactly** the requested number of events, or all remaining events if the end of the journal is reached first.
+- The response is capped at a maximum of **1.5 MB** regardless of the `limit` value.
 
-Once a `limit` query parameter is supplied, the value of the parameter is retained in the `next` link as well. Hence, you can continue using the `next` link as-is, without needing to construct it. The `limit` query parameter can also be combined with any other query parameter, just make sure that you pass a positive integer as the value.
+This is especially useful when experiencing high network latencies, as setting an appropriate `limit` reduces the number of round trips needed.
+
+Once a `limit` query parameter is supplied, the value is retained in the `next` link for subsequent requests — you can continue using the `next` link as-is without needing to reconstruct it. The `limit` parameter can also be combined with any other query parameter; make sure to pass a positive integer as the value.
 
 For example, here is the same request as before but with the number of events returned limited to just one:
 
@@ -351,88 +349,6 @@ Link: </events/organizations/23294/integrations/54108/f89067f2-0d50-4bb2-bf78-20
    "_page": {
       "last": "camel:5aeb25cc-1b15-4f26-a082-9c213005dba8:ff244403-ca7c-4993-bbda-3c8915ce0b32",
       "count": 1
-   }
-}
-```
-
-NOTE: The `limit` query parameter DOES NOT guarantee that the number of events returned will always be equal to the value supplied.
- This is true even if there are more events to be consumed in the journal.
- The `limit` query parameter only serves as a way to specify an upper bound on the count of events.
-
-For example, our journal above has at least 4 events that we know of, however, even when the `limit` parameter is supplied with the value `3`, we do not get that many events in the respsonse.
-
-```bash
-curl -X GET \
-  https://events-va6.adobe.io/organizations/23294/integrations/54108/f89067f2-0d50-4bb2-bf78-209d0eacb6eb?limit=3 \
-  -H "x-ims-org-id: 4CC7D9704674CFB2138A2C54@AdobeOrg" \
-  -H "Authorization: Bearer $USER_TOKEN" \
-  -H "x-api-key: $API_KEY"
-```
-
-```json
-HTTP/1.1 200 OK
-Link: </events/organizations/23294/integrations/54108/f89067f2-0d50-4bb2-bf78-209d0eacb6eb?since=moose:e7ba778b-dace-4994-96e7-da80e7125233:2159b72c-e284-4899-b572-08da250e3614&limit=3>; rel="next"
-
-{
-   "events":[
-      {
-         "position":"camel:5aeb25cc-1b15-4f26-a082-9c213005dba8:ff244403-ca7c-4993-bbda-3c8915ce0b32",
-         "event":{
-            "@id":"urn:oeid:aem:199e85da-dd54-4966-95ba-13cf544964dc",
-            "@type":"xdmCreated",
-            "activitystreams:published":"2018-03-06T15:19:03-08",
-            "activitystreams:to":{
-               "@type":"xdmImsOrg",
-               "xdmImsOrg:id":"01DC1FC45956A5810A494138@AdobeOrg"
-            },
-            "activitystreams:generator":{
-               "@type":"xdmContentRepository",
-               "xdmContentRepository:root":"http://localhost-roberto-aem63:4502"
-            },
-            "activitystreams:actor":{
-               "@id":"healthcheck-user",
-               "@type":"xdmAemUser"
-            },
-            "activitystreams:object":{
-               "@type":"xdmAsset",
-               "xdmAsset:asset_name":"healthcheck.png",
-               "xdmAsset:path":"/content/dam/healthcheck.png",
-               "xdmAsset:format":"image/png"
-            },
-            "xdmEventEnvelope:objectType":"xdmAsset"
-         }
-      },
-      {
-         "position":"moose:e7ba778b-dace-4994-96e7-da80e7125233:2159b72c-e284-4899-b572-08da250e3614",
-         "event":{
-            "@id":"urn:oeid:aem:61930ae6-ff2a-48fb-881d-078e862c3811",
-            "@type":"xdmCreated",
-            "activitystreams:published":"2018-03-06T15:19:59-08",
-            "activitystreams:to":{
-               "@type":"xdmImsOrg",
-               "xdmImsOrg:id":"01DC1FC45956A5810A494138@AdobeOrg"
-            },
-            "activitystreams:generator":{
-               "@type":"xdmContentRepository",
-               "xdmContentRepository:root":"http://localhost-roberto-aem63:4502"
-            },
-            "activitystreams:actor":{
-               "@id":"healthcheck-user",
-               "@type":"xdmAemUser"
-            },
-            "activitystreams:object":{
-               "@type":"xdmAsset",
-               "xdmAsset:asset_name":"healthcheck.png",
-               "xdmAsset:path":"/content/dam/healthcheck.png",
-               "xdmAsset:format":"image/png"
-            },
-            "xdmEventEnvelope:objectType":"xdmAsset"
-         }
-      }
-   ],
-   "_page": {
-      "last": "moose:e7ba778b-dace-4994-96e7-da80e7125233:2159b72c-e284-4899-b572-08da250e3614",
-      "count": 2
    }
 }
 ```

--- a/src/pages/guides/sdk/sdk-journaling.md
+++ b/src/pages/guides/sdk/sdk-journaling.md
@@ -26,7 +26,7 @@ The following options can be configured while calling the journaling API:
 |---|---|---|
 | [latest] | boolean | *Optional.* By default, the latest is set to false and all events are read from the first valid position in the journal. If set to true, Messages will be read from the latest position. |
 | [since] | string | *Optional.* Provide the position in the journal from where events must be fetched. If not specified and `latest=false`, messages are fetched from the first valid position in the journal. |
-| [limit] | number | Maximum number of events returned in the response. Note: unless the events are created at a high frequency, chances are the number of messages will be less than the specified limit value (see our [Journaling API](../api/journaling-api.md#limiting-the-size-of-the-batch) for more details) |
+| [limit] | number | The exact number of events to return in the response. The API returns exactly this many events, or all remaining events if the end of the journal is reached first. Responses are capped at 1.5 MB regardless of the limit value. See the [Journaling API](../api/journaling-api.md#limiting-the-size-of-the-batch) for more details. |
 | [seek] | string | *Optional.* Start fetching events from a specific point in time, using an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (e.g., `-PT2H` for 2 hours ago, `-P1D` for 1 day ago). Useful for [time-based queries](../api/journaling-api.md#starting-from-a-specific-point-in-time-with-the-seek-parameter). |
 
 ### EventsJournalPollingOptions

--- a/src/pages/guides/using/marketo/marketo-data-streams-developer-guidelines.md
+++ b/src/pages/guides/using/marketo/marketo-data-streams-developer-guidelines.md
@@ -15,7 +15,7 @@ Important Takeaways:
 
 ### Webhooks
 
-[Getting Started with Adobe I/O Events Webhooks](../../guides/index.md)
+[Getting Started with Adobe I/O Events Webhooks](../../index.md)
 
 Webhook Endpoint Requirements:
 

--- a/src/pages/support/faq.md
+++ b/src/pages/support/faq.md
@@ -302,9 +302,9 @@ To debug successful invocations, relay the `activation_id` of your target user a
 
 Adobe I/O stores 7 days of subscribed events, retrievable via the Journaling API.
 
-### Why do I only get one event, regardless of the `limit` I use?
+### How many events does the `limit` parameter return?
 
-The Journaling API `limit` parameter sets the **maximum** number of events returned. You may receive fewer events than the limit, depending on the incoming traffic. This is expected. For example, you may only see a single event in a journal batch/page even when the journal holds more than 1 event.
+When a `limit` is specified, the Journaling API returns **exactly** the requested number of events, or all remaining events if the end of the journal is reached first. Responses are capped at 1.5 MB regardless of the limit value. Setting an appropriate `limit` is especially useful when experiencing high network latencies, as it reduces the number of round trips needed.
 See the [Journaling API documentation](../guides/api/journaling-api.md#limiting-the-size-of-the-batch) for details.
 
 ### Can I retrieve all events in one request?

--- a/static/events-api-reference.yaml
+++ b/static/events-api-reference.yaml
@@ -543,7 +543,7 @@ paths:
           required: false
           type: integer
           format: int32
-          description: Maximum number of events to return in the batch
+          description: Requested number of events to return in the batch. Fewer events may be returned if the total payload size exceeds 1.5MB.
         - name: since
           in: query
           required: true
@@ -574,7 +574,7 @@ paths:
           required: false
           type: integer
           format: int32
-          description: Maximum number of events to return in the batch
+          description: Requested number of events to return in the batch. Fewer events may be returned if the total payload size exceeds 1.5MB.
         - name: since
           in: query
           required: false


### PR DESCRIPTION

## Description

When a limit is specified:                                                                                                                                                                           
                                                                                                                                                                                                       
  We will return *exactly* the number of events requested, or all remaining events if the end of the journal is reached first.                                                                         
  The response will be capped at a maximum of 1.5 MB regardless of the limit value.                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                
If you do not specify a limit parameter:                                                                                                                                                             
                                                                                                                                                                                                       
  We return a default number of events, but can return more depending on the incoming volume of events.    

## Related Issue

<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
